### PR TITLE
PENG-282 :: Add types code to the NPM library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuse-finance/ui-library",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "FuseFinance",
   "private": false,
   "type": "module",

--- a/src/components/BaseCodeEditor/baseTheme.tsx
+++ b/src/components/BaseCodeEditor/baseTheme.tsx
@@ -1,7 +1,7 @@
 import { createTheme } from '@uiw/codemirror-themes';
 import { tags as t } from '@lezer/highlight';
 
-import colors from '@/src/styles/colorsGlobal';
+import colors from '../../styles/colorsGlobal';
 
 // FIXME: The theme is intentionally dirty here to tweak quickly until we found the correct combination
 const baseTheme = createTheme({

--- a/src/components/EditableTitle/editableTitle.tsx
+++ b/src/components/EditableTitle/editableTitle.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { IEditLabelProps, WithSize } from './types';
 import { Input } from 'antd';
 import { InputRef } from 'antd/lib/input';
-import { StrongText } from '@/src/types/globalDesign/text';
+import { StrongText } from '../../types/globalDesign/text';
 import './editableTitle.css';
 
 

--- a/src/components/EditableTitle/types.tsx
+++ b/src/components/EditableTitle/types.tsx
@@ -1,4 +1,4 @@
-import { SizeGlobalValue } from '@/src/types/globalDesign/size';
+import { SizeGlobalValue } from '../../types/globalDesign/size';
 
 export interface WithSize {
   $size?: SizeGlobalValue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export * from './components';
+export * from './types/globalDesign';
+export * from './styles';

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,1 @@
+export { default as colors } from './colorsGlobal';

--- a/src/types/globalDesign/index.ts
+++ b/src/types/globalDesign/index.ts
@@ -1,0 +1,2 @@
+export type { SizeGlobalValue } from './size';
+export type { StrongTextValue } from './text';

--- a/src/types/globalDesign/types.stories.mdx
+++ b/src/types/globalDesign/types.stories.mdx
@@ -1,0 +1,29 @@
+import { Meta, Canvas } from '@storybook/addon-docs';
+
+<Meta title="/Types" />
+
+# Types
+
+## Size
+
+```jsx
+import {SizeGlobalValue} from '@fuse-finance/ui-library';
+
+```
+
+```jsx
+const example: SizeGlobalValue = "2xl";
+
+```
+
+## Strong Text
+```jsx
+import {StrongTextValue} from '@fuse-finance/ui-library';
+
+```
+
+```jsx
+const example: StrongTextValue = "medium";
+
+```
+

--- a/src/utility.stories.mdx
+++ b/src/utility.stories.mdx
@@ -1,0 +1,17 @@
+import { Meta, Canvas } from '@storybook/addon-docs';
+
+<Meta title="/Utility" />
+
+# Utility
+
+## Color
+
+```jsx
+import {colors} from '@fuse-finance/ui-library';
+
+```
+
+```jsx
+const example = colors.blue[400]
+
+```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
       "@/*": ["./*"],
       "@components/*": ["./src/components/*"],
       "@styles/*": ["./src/styles/*"],
-      "@types/*": ["./src/types/*"],
+      "@types_fuse/*": ["./src/types/*"],
       "@tests/*": ["./__tests__/*"]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       '@/': path.resolve(__dirname, './src'),
       '@components': path.resolve(__dirname, './src/components'),
       '@styles': path.resolve(__dirname, './src/styles'),
-      '@types': path.resolve(__dirname, './src/types'),
+      '@types_fuse': path.resolve(__dirname, './src/types'),
     },
   },
   plugins: [


### PR DESCRIPTION
Add reusable TypeScript data types and utilities:

- color
- text size 
- text strong

![image](https://github.com/FuseFinance/ui-library/assets/58958414/594b5402-bb9a-4006-9af1-48c8f1a171b3)
