### PR TITLE
PENG-369 :: Refactor modal in Ui-librery

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm install @storybook/addon-docs
       - run: npm install @storybook/addon-essentials
       - run: npm install @storybook/addon-storysource      
-      - run: npm run build
+      - run: npm run build-storybook
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/src/components/Modal/modal.mdx
+++ b/src/components/Modal/modal.mdx
@@ -1,0 +1,43 @@
+import { Meta, Canvas } from '@storybook/addon-docs';
+import StepModalHead from '@components/Modal/stepModalHead';
+import { IconList } from '@/src/components/Icons/types';
+
+<Meta title="Components/Modal/Modal" component={StepModalHead} />
+
+# Modal
+## Modal Import
+
+```jsx
+
+import { useState } from 'react';
+import { Button, Modal } from 'antd';
+
+```
+
+## Modal Example
+
+```jsx
+const ExampleModal = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const showModal = (e) => {
+    setIsModalOpen(true);
+  };
+  const handleOk = (e) => {
+    setIsModalOpen(false);
+  };
+  const handleCancel = (e) => {
+    setIsModalOpen(false);
+  };
+
+  return (<>
+    <Button type="primary" onClick={showModal}>
+      Open Modal
+    </Button>
+    <Modal closable={false} styles={{content:{padding:0}}} title={null} footer={null} open={isModalOpen} onOk={handleOk} onCancel={handleCancel}>
+      You content
+    </Modal>
+    </>)
+
+}
+```
+

--- a/src/components/Modal/modal.stories.tsx
+++ b/src/components/Modal/modal.stories.tsx
@@ -29,7 +29,7 @@ const Template = (args) => {
     <Button type="primary" onClick={showModal}>
       Open Modal
     </Button>
-    <Modal {...args} title={null} footer={null} open={isModalOpen} onOk={handleOk} onCancel={handleCancel}>
+    <Modal {...args} styles={{content:{padding:0}}} title={null} footer={null} open={isModalOpen} onOk={handleOk} onCancel={handleCancel}>
       You content
     </Modal>
     </>)

--- a/src/components/StepContent/SplitPath/splitPath.stories.tsx
+++ b/src/components/StepContent/SplitPath/splitPath.stories.tsx
@@ -88,7 +88,7 @@ const Template = () => {
     <Button type="primary" onClick={showModal}>
       Open Modal
     </Button>
-    <Modal width={640} title={null} footer={null} open={isModalOpen} onCancel={handleCancel}>
+    <Modal styles={{content:{padding:0}}} width={640} title={null} footer={null} open={isModalOpen} onCancel={handleCancel}>
       <div className="head-split-path pt-2 pb-2 pl-4 pr-12">
         <StepModalHead onLabelChange={onLabelChangeHead} icon={IconList.Branch} label='Split path' />
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -417,7 +417,10 @@ border: 3px solid transparent;
 }
 
 .ant-modal .ant-modal-content{
-  padding: 0;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-right: 1rem;
+  padding-left: 1rem;
 }
 
 .ant-modal .ant-modal-content{


### PR DESCRIPTION
With the import of Ui-librery to workflow-web, a visual defect was seen in the modal separation margins.

So adjustments will be made for the old ancient manners, to look aesthetically good and to be able to maintain the standards that were established in the Figma

And add extra documentation