### PR TITLE
PENG-526 :: Create component 'input code with text'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuse-finance/ui-library",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "FuseFinance",
   "private": false,
   "type": "module",

--- a/src/components/BaseCodeEditor/baseCodeEditor.stories.tsx
+++ b/src/components/BaseCodeEditor/baseCodeEditor.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react';
 import BaseCodeEditor from './baseCodeEditor';
 import { action } from '@storybook/addon-actions';
+import { javascript } from '@codemirror/lang-javascript';
 
 export default {
   title: 'Form/CodeEditor',
@@ -8,17 +9,6 @@ export default {
   args:{
     defaultValue: undefined,
     placeholder:'my placeholder',
-    plugins: [
-      {
-        "name": "customVars",
-        "isModule": true,
-        "decorationClass": "code-tag code-editor-hl-formula",
-        "options": {
-            "myOpntionOne()": "customVars"
-        },
-        "matchRegex": /customVars\.(myOpntionOne())\b\((.*?)\)/g
-      }
-    ],
     readonly: false,
     customCSSClass : undefined,
     containerCSSClass : undefined,
@@ -32,6 +22,11 @@ export default {
     customCSSClass: { control: 'text' },
     containerCSSClass: { control: 'text' },
     customContainerAttr: { control: 'object' },
+    extensions: {
+      table: {
+        disable: true,
+      },
+    },    
   },
 } as Meta;
 
@@ -43,10 +38,40 @@ const handleChange = (e) => {
   action('change input')(e);
 };
 
+
 export const CodeEditorInLine = Template.bind({});
 CodeEditorInLine.args = {
+  defaultValue: 'https://myweb.com/api/{{varName}}',
+  onChange: handleChange,
+  placeholder:'my placeholder', 
+  maxLines: 1,
+  plugins: [
+    {
+      "name": "interpolations",
+      "isModule": true,
+      "decorationClass": "code-tag code-editor-hl-interpolations",
+      "options": {},
+      "matchRegex": /\{\{\s*([^}}]*?)\s*\}\}/g
+    }
+  ],    
+};
+
+export const CodeEditorInLineWithJavascript = Template.bind({});
+CodeEditorInLineWithJavascript.args = {
   defaultValue: 'var myVar = customVars.myOpntionOne();',
   onChange: handleChange,
   placeholder:'my placeholder', 
-  maxLines: 1 
+  maxLines: 1,
+  extensions: [javascript()],
+  plugins: [
+    {
+      "name": "customVars",
+      "isModule": true,
+      "decorationClass": "code-tag code-editor-hl-formula",
+      "options": {
+          "myOpntionOne()": "customVars"
+      },
+      "matchRegex": /customVars\.(myOpntionOne())\b\((.*?)\)/g
+    }
+  ],
 };

--- a/src/components/BaseCodeEditor/baseCodeEditor.tsx
+++ b/src/components/BaseCodeEditor/baseCodeEditor.tsx
@@ -23,7 +23,7 @@ const BaseCodeEditor = forwardRef(({
   
   const internalRef = useRef();
   const ref = parentRef || internalRef;  
-
+  
   const editorConfig: BaseCodeEditorConfig = {
     onChange,
     onBlur,

--- a/src/components/BaseCodeEditor/codeEditor.stories.mdx
+++ b/src/components/BaseCodeEditor/codeEditor.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Canvas } from '@storybook/addon-docs';
 import BaseCodeEditor from './baseCodeEditor';
+import { javascript } from '@codemirror/lang-javascript';
 
 <Meta title="Form/CodeEditor" component={BaseCodeEditor} />
 
@@ -17,10 +18,36 @@ import { BaseCodeEditor } from '@fuse-finance/ui-library';
 ## Code Edit In Line
 <Canvas>
   <BaseCodeEditor
+    defaultValue = 'https://myweb.com/api/{{varName}}'
+    onChange = {console.log}
+    customCSSClass = ''
+    placeholder='my placeholder'
+    maxLines={1}
+    plugins = {[
+      {
+        "name": "interpolations",
+        "isModule": true,
+        "decorationClass": "code-tag code-editor-hl-interpolations",
+        "options": {},
+        "matchRegex": /\{\{\s*([^}}]*?)\s*\}\}/g
+      }
+    ]}    
+  />  
+</Canvas> 
+
+## Code Edit In Line With JavaScript
+```jsx
+import { javascript } from '@codemirror/lang-javascript';
+```
+
+<Canvas>
+  <BaseCodeEditor
     defaultValue = 'var myVar = customVars.myOpntionOne()'
     onChange = {console.log}
     customCSSClass = ''
     placeholder='my placeholder'
+    maxLines={1}
+    extensions= {[javascript()]}
     plugins = {[
       {
         "name": "customVars",
@@ -34,4 +61,3 @@ import { BaseCodeEditor } from '@fuse-finance/ui-library';
     ]}    
   />  
 </Canvas> 
-

--- a/src/components/BaseCodeEditor/hooks.tsx
+++ b/src/components/BaseCodeEditor/hooks.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { get } from 'lodash';
-import { javascript } from '@codemirror/lang-javascript';
 import { autocompletion, closeBrackets } from '@codemirror/autocomplete';
 import { indentOnInput, bracketMatching, foldGutter } from '@codemirror/language';
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
@@ -197,7 +196,6 @@ export const useBaseCodeEditorConfig = ({
     (view: EditorView) => {
       const baseExtensions = [
         theme,
-        javascript(),
         ph(placeholder),
         history(),
         foldGutter(),

--- a/src/components/CodeEditorTextArea/codeEditorTextArea.stories.mdx
+++ b/src/components/CodeEditorTextArea/codeEditorTextArea.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Canvas } from '@storybook/addon-docs';
 import { CodeEditorTextArea } from './';
+import { javascript } from '@codemirror/lang-javascript';
 
 <Meta title="Form/CodeEditorTextArea" component={CodeEditorTextArea} />
 
@@ -10,7 +11,7 @@ import { CodeEditorTextArea } from './';
 ```jsx
 
 import { CodeEditorTextArea } from '@fuse-finance/ui-library';
-
+import { javascript } from '@codemirror/lang-javascript';
 
 ```
 
@@ -21,6 +22,7 @@ import { CodeEditorTextArea } from '@fuse-finance/ui-library';
     onChange = {console.log}
     customCSSClass = ''
     placeholder='my placeholder'
+    extensions = {[javascript()]}
     plugins = {[
       {
         "name": "customVars",
@@ -44,6 +46,7 @@ import { CodeEditorTextArea } from '@fuse-finance/ui-library';
     placeholder='my placeholder'
     minHeightLines={2}
     maxHeightLines={4.5}
+    extensions = {[javascript()]}
     plugins = {[
       {
         "name": "customVars",

--- a/src/components/CodeEditorTextArea/codeEditorTextArea.stories.tsx
+++ b/src/components/CodeEditorTextArea/codeEditorTextArea.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react';
 import { CodeEditorTextArea } from './';
 import { action } from '@storybook/addon-actions';
+import { javascript } from '@codemirror/lang-javascript';
 
 export default {
   title: 'Form/CodeEditorTextArea',
@@ -31,6 +32,11 @@ export default {
       control: 'text', 
       defaultValue: undefined
     },
+    extensions: { // remove option
+      table: {
+        disable: true,
+      },
+    },    
     customCSSClass: { control: 'text' },
     containerCSSClass: { control: 'text' },
     customContainerAttr: { control: 'object' },
@@ -48,9 +54,10 @@ const handleChange = (e) => {
   action('change input')(e);
 };
 
-export const CodeEditorInLine = Template.bind({});
-CodeEditorInLine.args = {
+export const CodeEditorTextAreaExample = Template.bind({});
+CodeEditorTextAreaExample.args = {
   defaultValue: "{\n\n}",
   onChange: handleChange,
-  placeholder: "{}",  
+  placeholder: "{}",
+  extensions: [javascript()]
 };


### PR DESCRIPTION
Although the "input code" has already been created, an input that allows adding normal text plus code needs to be added.

This is used for example in the "API Call"

This will be added in Storybook

![image](https://github.com/FuseFinance/ui-library/assets/58958414/2173a71e-c15d-4fbb-acf0-5831563089d9)
